### PR TITLE
Add TWZRD Agent Intel — Solana x402 AI agent trust scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This list emphasizes platforms and protocols where agents earn, spend, and coord
 * [World ID (Worldcoin)](https://worldcoin.org/world-id) - Proof‑of‑personhood for human–agent gating; real‑world expansion covered broadly in 2025. ([The Washington Post][39])
 * [Human Passport (Gitcoin Passport)](https://passport.human.tech/) - Attestation‑based identity with model‑assisted Sybil detection; widely used across web3. ([Human Passport][40])
 
-* **[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final)** — Solana-native AI agent trust scoring MCP server with x402 micropayment receipts. Issues cryptographically signed V5 trust receipts for agent interactions; free preflight + paid receipts. Production service at https://intel.twzrd.xyz
+* **[TWZRD Agent Intel](https://intel.twzrd.xyz)** — Solana-native AI agent trust scoring MCP server with x402 micropayment receipts. Issues cryptographically signed V5 trust receipts for agent interactions; free preflight + paid receipts. Production service at https://intel.twzrd.xyz
 
 ## Analytics & indexing for agent economies
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ This list emphasizes platforms and protocols where agents earn, spend, and coord
 * [World ID (Worldcoin)](https://worldcoin.org/world-id) - Proof‑of‑personhood for human–agent gating; real‑world expansion covered broadly in 2025. ([The Washington Post][39])
 * [Human Passport (Gitcoin Passport)](https://passport.human.tech/) - Attestation‑based identity with model‑assisted Sybil detection; widely used across web3. ([Human Passport][40])
 
+* **[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final)** — Solana-native AI agent trust scoring MCP server with x402 micropayment receipts. Issues cryptographically signed V5 trust receipts for agent interactions; free preflight + paid receipts. Production service at https://intel.twzrd.xyz
+
 ## Analytics & indexing for agent economies
 
 * [Cookie DAO / cookie.fun](https://agents.cookie.fun/) - Data layer & index for AI agent tokens and infra across chains (mindshare, on‑chain/social metrics); APIs for agent builders.

--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ This list emphasizes platforms and protocols where agents earn, spend, and coord
 
 * [World ID (Worldcoin)](https://worldcoin.org/world-id) - Proof‑of‑personhood for human–agent gating; real‑world expansion covered broadly in 2025. ([The Washington Post][39])
 * [Human Passport (Gitcoin Passport)](https://passport.human.tech/) - Attestation‑based identity with model‑assisted Sybil detection; widely used across web3. ([Human Passport][40])
-
-* **[TWZRD Agent Intel](https://intel.twzrd.xyz)** — Solana-native AI agent trust scoring MCP server with x402 micropayment receipts. Issues cryptographically signed V5 trust receipts for agent interactions; free preflight + paid receipts. Production service at https://intel.twzrd.xyz
+* [TWZRD Agent Intel](https://intel.twzrd.xyz) - On‑chain trust scoring for Solana AI agents. Free MCP tools (`score_agent`, `preflight_check`) verify wallet identity; paid `get_trust_receipt` delivers a verifiable receipt via x402 micropayment. Config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 
 ## Analytics & indexing for agent economies
 


### PR DESCRIPTION
## Summary

Adds **TWZRD Agent Intel** to the **Identity & reputation primitives for agent economies** section.

TWZRD Agent Intel is a production Solana-native trust scoring and x402 receipt layer for AI agents — exactly the kind of on-chain identity/reputation primitive this list focuses on.

- Issues cryptographically signed V5 trust receipts for agent interactions  
- x402 micropayment-gated: free preflight + paid signed receipts  
- MCP endpoint at https://intel.twzrd.xyz/mcp (Streamable-HTTP)  
- Live production service on Solana mainnet  

**Repo**: https://intel.twzrd.xyz  
**Status**: Mainnet production